### PR TITLE
Fixed continuous list palettes in get_scales_list

### DIFF
--- a/R/scales.R
+++ b/R/scales.R
@@ -189,7 +189,7 @@ get_scale_list <- function(pal_object,
       func <- ifelse(scale_type == "colour",
                      scale_color_gradientn,
                      scale_fill_gradientn)
-      func(colours = pal_object(palette      = palette,
+      func(colours = palette_func(palette      = palette,
                                 palette_list = palette_list,
                                 alpha   = alpha,
                                 reverse = reverse,


### PR DESCRIPTION
I am new to pull requests, so please let me know if this doesn't meet your standards or you have any questions.

This addresses the issue #1 by swapping out the reference from "pal_object", which is not callable as a function, to "palette_func", which is the function defined in the lexical closure.
